### PR TITLE
Allow additional characters in RestrictedSecurity profile constraints

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -1550,7 +1550,7 @@ public final class RestrictedSecurity {
 
             // Check whether constraints are properly specified.
             final String typeRE = "\\w+";
-            final String algoRE = "[A-Za-z0-9./_-]+";
+            final String algoRE = "[A-Za-z0-9./_:#-]+";
             final String attrRE = "[A-Za-z0-9=*|.:]+";
             final String usesRE = "[A-Za-z0-9._:/$]+";
             final String consRE = "\\{(" + typeRE + "),(" + algoRE + "),(" + attrRE + ")(," + usesRE + ")?\\}";
@@ -1896,7 +1896,7 @@ public final class RestrictedSecurity {
                 + "(\\["                                // constraints [optional]
                     + "\\s*"
                     + "([+-])?"                         // action [optional]
-                    + "[A-Za-z0-9{}.=*|:$,/_\\s-]+"     // constraint definition
+                    + "[A-Za-z0-9{}.=*|:$#,/_\\s-]+"    // constraint definition
                 + "\\])?"
                 + "\\s*"
                 + "$");


### PR DESCRIPTION
Some more characters, like `#` and `:`, need to be allowed in RestrictedSecurity profile constraints, specifically the algorithm portion.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1036

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>