### PR TITLE
Remove temp change from libClearAllFramePops.cpp

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/ClearAllFramePops/libClearAllFramePops.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/ClearAllFramePops/libClearAllFramePops.cpp
@@ -21,12 +21,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
- * ===========================================================================
- */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -152,7 +146,7 @@ JNIEXPORT void JNICALL Java_ClearAllFramePops_clearAllFramePops(JNIEnv *jni, jcl
 
   char* tname = get_thread_name(jvmti, jni, nullptr);
 
-  /* check_jvmti_status(jni, jvmti->ClearAllFramePops(nullptr), "Error in ClearAllFramePops"); */
+  check_jvmti_status(jni, jvmti->ClearAllFramePops(nullptr), "Error in ClearAllFramePops");
   LOG("Called ClearAllFramePops for thread: %s\n", tname);
 
   deallocate(jvmti, jni, tname);


### PR DESCRIPTION
The code should have been restored when ClearAllFramePops was stubbed via https://github.com/eclipse-openj9/openj9/pull/21168

Closes https://github.com/eclipse-openj9/openj9/issues/20980

Backport https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1050