### PR TITLE
Reduce LotsOfContendedMonitorEnter test size

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java
@@ -26,14 +26,14 @@
  * @summary Test virtual threads entering a lot of monitors with contention
  * @requires vm.opt.LockingMode != 1
  * @library /test/lib
- * @run main LotsOfContendedMonitorEnter
+ * @run main/othervm -Xiss32K -XX:ContinuationCache:t1=8,t2=64 LotsOfContendedMonitorEnter
  */
 
 /*
  * @test id=LM_LIGHTWEIGHT
  * @requires vm.opt.LockingMode != 1
  * @library /test/lib
- * @run main/othervm -XX:LockingMode=2 LotsOfContendedMonitorEnter
+ * @run main/othervm -Xiss32K -XX:ContinuationCache:t1=8,t2=64 -XX:LockingMode=2 LotsOfContendedMonitorEnter
  */
 
 import java.util.concurrent.CountDownLatch;
@@ -46,7 +46,7 @@ public class LotsOfContendedMonitorEnter {
         if (args.length > 0) {
             depth = Integer.parseInt(args[0]);
         } else {
-            depth = 1024;
+            depth = 128;
         }
         VThreadRunner.run(() -> testContendedEnter(depth));
     }


### PR DESCRIPTION
There is a known performance issue with OpenJ9 causing this test to
timeout, this change is to temporarily reduce the size of the test to
retain test coverage while the perf issue is being addressed.

Tracking issue: https://github.com/eclipse-openj9/openj9/issues/22153

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>