### PR TITLE
Add and fix debug messages in RestrictedSecurity

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -1892,8 +1892,8 @@ public final class RestrictedSecurity {
 
                 String action = m.group(4);
                 if (!update && !isNullOrBlank(action)) {
-                    printStackTraceAndExit("You cannot add or remove to provider "
-                            + m.group(1) + ". This is the base profile.");
+                    printStackTraceAndExit("Constraints of provider not previously specified"
+                            + " cannot be modified: " + providerName);
                 }
             } else {
                 printStackTraceAndExit("Provider format is incorrect: " + providerInfo);

--- a/src/java.base/share/classes/sun/security/jca/ProviderList.java
+++ b/src/java.base/share/classes/sun/security/jca/ProviderList.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -110,6 +110,10 @@ public final class ProviderList {
         if (!RestrictedSecurity.isProviderAllowed(p.getClass())) {
             // We're in restricted security mode which does not allow this provider,
             // return without adding.
+            if (debug != null) {
+                debug.println("In RestrictedSecurity mode. Provider " +
+                        p.getClass().getName() + " not allowed to be inserted.");
+            }
             return providerList;
         }
         if (providerList.getProvider(p.getName()) != null) {


### PR DESCRIPTION
The exception message when trying to add or remove constraints to a previously non-existing provider is fixed.

A debug message is added to the `ProviderList` to indicate when a provider not allowed in `RestrictedSecurity` mode is not added to the providers list.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1062

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>