### PR TITLE
Exclude SetClientMode test in FIPS 140-3 excludes

### DIFF
--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3-Strongly-Enforced.txt
@@ -1019,6 +1019,7 @@ sun/security/ssl/SSLSocketImpl/SSLSocketSSLEngineCloseInbound.java https://githu
 sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/ServerRenegoWithTwoVersions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/ServerTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLSocketImpl/SetClientMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/SetSoTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/UnconnectedSocketWrongExceptions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJCEPlusFIPS.FIPS140-3.txt
@@ -1017,6 +1017,7 @@ sun/security/ssl/SSLSocketImpl/SSLSocketSSLEngineCloseInbound.java https://githu
 sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/ServerRenegoWithTwoVersions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/ServerTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
+sun/security/ssl/SSLSocketImpl/SetClientMode.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/SetSoTimeout.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all
 sun/security/ssl/SSLSocketImpl/UnconnectedSocketWrongExceptions.java https://github.com/eclipse-openj9/openj9/issues/20343 generic-all

--- a/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
+++ b/test/jdk/ProblemList-FIPS140_3_OpenJcePlus.txt
@@ -918,6 +918,7 @@ sun/security/ssl/SSLSocketImpl/SSLSocketSSLEngineCloseInbound.java https://githu
 sun/security/ssl/SSLSocketImpl/SSLSocketShouldThrowSocketException.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SSLSocketImpl/ServerRenegoWithTwoVersions.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SSLSocketImpl/ServerTimeout.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
+sun/security/ssl/SSLSocketImpl/SetClientMode.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SSLSocketImpl/SetSoTimeout.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SSLSocketImpl/SocketExceptionForSocketIssues.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all
 sun/security/ssl/SSLSocketImpl/UnconnectedSocketWrongExceptions.java https://github.com/eclipse-openj9/openj9/issues/20978 generic-all


### PR DESCRIPTION
This test fails as follows :

```
Execution failed: `main' threw exception: java.lang.SecurityException:
Property 'jdk.tls.disabledAlgorithms' cannot be set programmatically
when in FIPS mode
```

This test should be excluded accordingly.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1071