### PR TITLE
Fix minimum allocation size

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
- * ===========================================================================
- */
-
 package jdk.internal.foreign;
 
 import jdk.internal.access.foreign.UnmapperProxy;
@@ -203,8 +197,9 @@ public class SegmentFactories {
             throw new OutOfMemoryError();
         }
         // Always allocate at least some memory so that zero-length segments have distinct
-        // non-zero addresses.
-        alignedSize = Math.max(Long.BYTES, alignedSize);
+        // non-zero addresses. If we are initializing the allocated memory, then use a minimum
+        // size of 8 because we init the memory with longs.
+        alignedSize = Math.max((init ? Long.BYTES : 1), alignedSize);
 
         long allocationSize;
         long allocationBase;


### PR DESCRIPTION
Fix for Issue eclipse-openj9/openj9#22219
If the init flag is set to true
ensure min allocation size of Long.BYTES.
initNativeMemory() writes a full long (Long.BYTES). 
1-byte allocation is not enough and can corrupt the footer.

This change was suggested during the review of the corresponding PR in OpenJDK(https://github.com/openjdk/jdk/pull/27027). Replaces https://github.com/ibmruntimes/openj9-openjdk-jdk25/pull/32

Backport https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1086