### PR TITLE
Add RAM_CLASS_CACHE_SUPPORT JPP flag

### DIFF
--- a/closed/JPP.gmk
+++ b/closed/JPP.gmk
@@ -45,6 +45,10 @@ ifeq (true,$(BUILD_OPENJCEPLUS))
   JPP_TAGS += OPENJCEPLUS_SUPPORT
 endif # BUILD_OPENJCEPLUS
 
+ifeq (true,$(OPENJ9_ENABLE_SNAPSHOTS))
+  JPP_TAGS += RAM_CLASS_CACHE_SUPPORT
+endif # OPENJ9_ENABLE_SNAPSHOTS
+
 # invoke JPP to preprocess java source files
 # $1 - configuration
 # $2 - source directory


### PR DESCRIPTION
The flag is required and a part of
by https://github.com/eclipse-openj9/openj9/pull/22289