### PR TITLE
Remove obsolete J9VERSION_STRING from openj9_version_info.h

### DIFF
--- a/closed/openj9_version_info.h.in
+++ b/closed/openj9_version_info.h.in
@@ -32,7 +32,6 @@
 #define J9TARGET_CPU_OSARCH       "@OPENJDK_TARGET_CPU_OSARCH@"
 #define J9TARGET_OS               "@OPENJDK_TARGET_OS@"
 #define J9USERNAME                "@USERNAME@"
-#define J9VERSION_STRING          "@VERSION_STRING@"
 #define JAVA_VENDOR               "@COMPANY_NAME@"
 #define JDK_DEBUG_LEVEL           "@DEBUG_LEVEL@"
 #define OPENJ9_TAG                "@OPENJ9_TAG@"


### PR DESCRIPTION
Backport https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1098