### PR TITLE
Cleanup LUDCL cache invalidation and restoration logic

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -348,20 +348,19 @@ public class ObjectInputStream
      */
     private boolean streamFilterSet;
 
-    /* Cache LUDCL (Latest User-Defined Class Loader) until completion of read requests.
-     * If true LUDCL/forName results would be cached, true by default starting with Java 8.
+    /*
+     * Unless system property "com.ibm.enableClassCaching" is false, cache LUDCL
+     * (Latest User-Defined Class Loader) until completion of read requests.
      */
-    private static final boolean isClassCachingEnabled =
-            Boolean.parseBoolean(System.getProperty("com.ibm.enableClassCaching", "true"));
-    /* ClassByNameCache Entry for caching class.forName results upon enableClassCaching. */
     private static final ClassByNameCache classByNameCache =
-            isClassCachingEnabled ? new ClassByNameCache() : null;
+            Boolean.parseBoolean(System.getProperty("com.ibm.enableClassCaching", "true"))
+                ? new ClassByNameCache()
+                : null;
 
-    private ClassLoader cachedLudcl;
     /* If user code is invoked in the middle of a call to readObject the cachedLudcl
      * must be refreshed as the ludcl could have been changed while in user code.
      */
-    private boolean refreshLudcl;
+    private ClassLoader cachedLudcl;
     private Object startingLudclObject;
 
     /**
@@ -530,7 +529,7 @@ public class ObjectInputStream
         ClassLoader oldCachedLudcl = null;
         boolean setCached = false;
 
-        if (((null == curContext) || refreshLudcl) && isClassCachingEnabled) {
+        if ((null != classByNameCache) && ((null == curContext) || (null == cachedLudcl))) {
             oldCachedLudcl = cachedLudcl;
             setCached = true;
 
@@ -538,10 +537,9 @@ public class ObjectInputStream
             // Otherwise use the class loader provided by JIT as the cachedLudcl.
 
             if (caller == null) {
-                refreshLudcl = true;
+                cachedLudcl = null;
             } else {
                 cachedLudcl = caller.getClassLoader();
-                refreshLudcl = false;
             }
 
             if (null == startingLudclObject) {
@@ -566,13 +564,12 @@ public class ObjectInputStream
         } finally {
             /* Back to the start, refresh ludcl cache on next call. */
             if (this == startingLudclObject) {
-                refreshLudcl = true;
+                cachedLudcl = null;
                 startingLudclObject = null;
-            }
-            passHandle = outerHandle;
-            if (setCached) {
+            } else if (setCached) {
                 cachedLudcl = oldCachedLudcl;
             }
+            passHandle = outerHandle;
             if (closed && depth == 0) {
                 clear();
             }
@@ -649,10 +646,10 @@ public class ObjectInputStream
         ClassLoader oldCachedLudcl = null;
         boolean setCached = false;
 
-        if (((null == curContext) || refreshLudcl) && isClassCachingEnabled) {
+        if ((null != classByNameCache) && ((null == curContext) || (null == cachedLudcl))) {
             oldCachedLudcl = cachedLudcl;
             setCached = true;
-            refreshLudcl = true;
+            cachedLudcl = null;
             if (null == startingLudclObject) {
                 startingLudclObject = this;
             }
@@ -675,13 +672,12 @@ public class ObjectInputStream
         } finally {
             /* Back to the start, refresh ludcl cache on next call. */
             if (this == startingLudclObject) {
-                refreshLudcl = true;
+                cachedLudcl = null;
                 startingLudclObject = null;
-            }
-            passHandle = outerHandle;
-            if (setCached) {
+            } else if (setCached) {
                 cachedLudcl = oldCachedLudcl;
             }
+            passHandle = outerHandle;
             if (closed && depth == 0) {
                 clear();
             }
@@ -841,9 +837,8 @@ public class ObjectInputStream
             if (null == classByNameCache) {
                 return Class.forName(name, false, latestUserDefinedLoader());
             } else {
-                if (refreshLudcl) {
+                if (null == cachedLudcl) {
                     cachedLudcl = latestUserDefinedLoader();
-                    refreshLudcl = false;
                 }
                 return classByNameCache.get(name, cachedLudcl);
             }
@@ -2244,7 +2239,7 @@ public class ObjectInputStream
             desc.hasReadResolveMethod())
         {
             /* user code is invoked */
-            refreshLudcl = true;
+            cachedLudcl = null;
             Object rep = desc.invokeReadResolve(obj);
             if (unshared && rep.getClass().isArray()) {
                 rep = cloneArray(rep);
@@ -2407,7 +2402,7 @@ public class ObjectInputStream
                         bin.setBlockDataMode(true);
 
                         /* user code is invoked */
-                        refreshLudcl = true;
+                        cachedLudcl = null;
                         slotDesc.invokeReadObject(obj, this);
                     } catch (ClassNotFoundException ex) {
                         /*
@@ -2456,7 +2451,7 @@ public class ObjectInputStream
                     handles.lookupException(passHandle) == null)
                 {
                     /* user code is invoked */
-                    refreshLudcl = true;
+                    cachedLudcl = null;
                     slotDesc.invokeReadObjectNoData(obj);
                 }
             }


### PR DESCRIPTION
This cleans up the invalidation and restoration of cached 'latest user defined classloader' references when passing between user and platform code during object deserialization.

We also take this opportunity to remove the unnecessary `isClassCachingEnabled` instance variable and replace its usage with the equivalent `classByNameCache != null`.

It is known that this fixes #20916, and it may also fix #9912 but that is as yet unvalidated.


(cherry picked from commit 7ce8262620a26dac48a8548b70f42b160ab71415)