### PR TITLE
Map illegal characters in the branch name to '-'

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -76,6 +76,9 @@ else
   ifeq (,$(OPENJ9_BRANCH))
     $(error Could not determine OpenJ9 branch)
   endif
+  # Map characters in the branch name other than [A-Za-z0-9.] to '-' so the resulting
+  # version string is acceptable to Runtime.Version.parse().
+  OPENJ9_BRANCH := $(shell $(PRINTF) '%s' '$(OPENJ9_BRANCH)' | $(TR) -c 'A-Za-z0-9.' '-')
   OPENJ9_VERSION_STRING := $(OPENJ9_BRANCH)-$(OPENJ9_SHA)
 endif
 


### PR DESCRIPTION
So the result is acceptable to `Runtime.Version.parse()`.

This is a backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1116.