### PR TITLE
Fix one deadlock in RestrictedSecurity mode DeadLock test

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -28,6 +28,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Provider.Service;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -640,7 +641,7 @@ public final class RestrictedSecurity {
         if (!isNullOrBlank(descSunsetDate)) {
             try {
                 isSunset = LocalDate.parse(descSunsetDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-                        .isBefore(LocalDate.now());
+                        .isBefore(LocalDate.now(Clock.systemUTC()));
             } catch (DateTimeParseException except) {
                 printStackTraceAndExit(
                         "Restricted security policy sunset date is incorrect, the correct format is yyyy-MM-dd.");


### PR DESCRIPTION
This is a back port PR from Next PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1097

This PR fixes one issues when running DeadLock test in RestrictedSecurity mode.

The issue arises from the RestrictedSecurity.isPolicySunset() method.

In the Deadlock test, thread 1 attempts to obtain a SecureRandom instance. As part of this process, it calls into the RestrictedSecurity code, which invokes isPolicySunset(). This method uses LocalDate() to retrieve the current date, which in turn triggers the loading of time zone data (tzdb) from JAR files.

At the same time, thread 2 in the same test is attempting to load a JAR file to verify a signed class. The JAR loading process acquires a lock, and thread 2 is left waiting to obtain the signature verification algorithm.

This leads to a deadlock. Thread 2 holds the lock on JAR loading, waiting for the provider to initialize so it can perform signature verification. Thread 1 is blocked in RestrictedSecurity.isPolicySunset(), attempting to load tzdb from the JAR, which is already locked by thread 2.

As a result, both threads wait indefinitely, causing the test to hang. The issue is resolved by using LocalDate.now(Clock.systemUTC()), which avoids loading time zone data (tzdb) from JAR files.