### PR TITLE
Change bundled OpenSSL SONAME for Linux Platforms

### DIFF
--- a/closed/custom/modules/java.base/Copy-post.gmk
+++ b/closed/custom/modules/java.base/Copy-post.gmk
@@ -203,7 +203,7 @@ endif # OPENJ9_ENABLE_JFR
 # To bundle first search for openssl 1.1.x library, if not found, search for 1.0.x
 ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   ifeq (linux,$(OPENJDK_TARGET_OS))
-    LIBCRYPTO_NAMES := libcrypto.so.3 libcrypto.so.1.1 libcrypto.so.1.0.0
+    LIBCRYPTO_NAMES := libcrypto-semeru.so libcrypto.so.3 libcrypto.so.1.1 libcrypto.so.1.0.0
   else ifeq (macosx,$(OPENJDK_TARGET_OS))
     LIBCRYPTO_NAMES := libcrypto.3.dylib libcrypto.1.1.dylib libcrypto.1.0.0.dylib
   else ifeq (windows,$(OPENJDK_TARGET_OS))
@@ -240,7 +240,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
 
   ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
     ifeq (linux,$(OPENJDK_TARGET_OS))
-      LIBSSL_NAMES := libssl.so.3 libssl.so.1.1 libssl.so.1.0.0
+      LIBSSL_NAMES := libssl-semeru.so libssl.so.3 libssl.so.1.1 libssl.so.1.0.0
       LIBSSL_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBSSL_NAMES))))
 
       ifneq ($(LIBSSL_PATH), )

--- a/closed/openssl-conf/semeru.conf
+++ b/closed/openssl-conf/semeru.conf
@@ -1,0 +1,41 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+my %targets = (
+	"semeru"            => { shlib_variant => "-semeru", template => 1 },
+	"semeru-linux"      => {
+		inherit_from        => [ "semeru" ],
+		shared_extension    => ".so",
+		shared_ldflag       => add("-Wl,-rpath,'\$\$'ORIGIN"),
+		template            => 1
+	},
+
+	"semeru-ap64"       => { inherit_from => [ "aix64-cc" ] },
+	"semeru-ap64-clang" => { inherit_from => [ "aix64-clang" ] },
+	"semeru-oa64"       => { inherit_from => [ "darwin64-x86_64-cc" ] },
+	"semeru-or64"       => { inherit_from => [ "darwin64-arm64-cc" ] },
+	# The name must start with "VC-", otherwise Windows builds fail.
+	"VC-wa64"           => { inherit_from => [ "VC-WIN64A" ] },
+	"semeru-xa64"       => { inherit_from => [ "semeru-linux", "linux-x86_64" ] },
+	"semeru-xl64"       => { inherit_from => [ "semeru-linux", "linux-ppc64le" ] },
+	"semeru-xr64"       => { inherit_from => [ "semeru-linux", "linux-aarch64" ] },
+	"semeru-xv64"       => { inherit_from => [ "semeru-linux", "linux64-riscv64" ] },
+	"semeru-xz64"       => { inherit_from => [ "semeru-linux", "linux64-s390x" ] },
+);

--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -27,7 +27,7 @@ endif
 include $(SPEC)
 include MakeBase.gmk
 
-ifeq ($(OPENJDK_TARGET_OS), windows)
+ifeq ($(call isTargetOs, windows), true)
   # Configure normally demands that we use an implementation of perl that produces
   # paths with backslashes; CONFIGURE_INSIST bypasses that requirement.
   # PERL must be an absolute path that will be usable by nmake (i.e. start with
@@ -61,38 +61,17 @@ else # windows
 endif # windows
 
 # Identify the desired openssl target configuration.
-OPENSSL_TARGET :=
-ifeq ($(OPENJDK_TARGET_OS), aix)
-  ifeq ($(call isCompiler, clang), true)
-    OPENSSL_TARGET := aix64-clang
-  else ifeq ($(call isCompiler, xlc), true)
-    OPENSSL_TARGET := aix64-cc
-  endif
-else ifeq ($(OPENJDK_TARGET_OS), linux)
-  ifneq (,$(filter aarch64 ppc64le x86_64, $(OPENJDK_TARGET_CPU)))
-    OPENSSL_TARGET := linux-$(OPENJDK_TARGET_CPU)
-  else ifneq (,$(filter riscv64 s390x, $(OPENJDK_TARGET_CPU)))
-    OPENSSL_TARGET := linux64-$(OPENJDK_TARGET_CPU)
-  endif
-else ifeq ($(OPENJDK_TARGET_OS), macosx)
-  ifneq (,$(filter arm64 x86_64, $(OPENJDK_TARGET_CPU)))
-    OPENSSL_TARGET := darwin64-$(OPENJDK_TARGET_CPU)-cc
-  else ifeq ($(OPENJDK_TARGET_CPU), aarch64)
-    OPENSSL_TARGET := darwin64-arm64-cc
-  endif
-else ifeq ($(OPENJDK_TARGET_OS), windows)
-  ifeq ($(OPENJDK_TARGET_CPU), x86_64)
-    OPENSSL_TARGET := VC-WIN64A
-  else
-    OPENSSL_TARGET := VC-WIN32
-  endif
-endif # OPENJDK_TARGET_OS
+export OPENSSL_LOCAL_CONFIG_DIR := $(call MixedPath,$(TOPDIR)/closed/openssl-conf)
 
-ifeq (,$(OPENSSL_TARGET))
-  $(error Unsupported platform $(OPENJDK_TARGET_OS)-$(OPENJDK_TARGET_CPU))
-endif # OPENSSL_TARGET
+ifeq ($(call isTargetOs, aix)+$(call isCompiler, clang), true+true)
+  OPENSSL_TARGET := semeru-$(OPENJ9_PLATFORM_CODE)-clang
+else ifeq ($(call isTargetOs, windows), true)
+  OPENSSL_TARGET := VC-$(OPENJ9_PLATFORM_CODE)
+else
+  OPENSSL_TARGET := semeru-$(OPENJ9_PLATFORM_CODE)
+endif
 
-ifeq ($(OPENJDK_TARGET_CPU), s390x)
+ifeq ($(call isTargetCpu, s390x), true)
   OPENSSL_CONFIG_CFLAGS := -march=z10
 else
   OPENSSL_CONFIG_CFLAGS :=
@@ -108,7 +87,7 @@ endif # CCACHE
 
 build_openssl :
 	@$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR) for $(OPENSSL_TARGET)$(if $(OPENSSL_CONFIG_CFLAGS), with additional CFLAGS $(OPENSSL_CONFIG_CFLAGS))
-	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_CONFIG_CFLAGS) $(OPENSSL_TARGET) no-makedepend no-tests shared )
+	( $(OPENSSL_CONFIG_SETUP) $(CD) $(OPENSSL_DIR) && $(PERL) Configure $(OPENSSL_CONFIG_CFLAGS) $(OPENSSL_TARGET) no-makedepend no-tests no-winstore shared )
 	$(OPENSSL_PATCH)
 	+ ( $(OPENSSL_MAKE_SETUP) $(CD) $(OPENSSL_DIR) && $(OPENSSL_MAKE) )
 


### PR DESCRIPTION
JDK-bundled libcrypto-semeru.so and libssl-semeru.so used to have the same SONAME as the operating system libcrypto.so and libssl.so. When the dynamic linker tries to resolve a libssl.so’s dependency on libcrypto.so.3, it will match the already-loaded $JAVA_HOME/lib/libcrypto-semeru.so (whose SONAME was also libcrypto.so.3). These two libcrypto.so.3 come from different distributions and their symbol versions are incompatible, this will hit an exception.