### PR TITLE
Wire any configured sysroot through to the OpenJ9 build on macOS

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -287,6 +287,12 @@ else
   endif
 endif # windows
 
+ifeq ($(call isTargetOs, macosx), true)
+  ifneq (,$(SYSROOT))
+    CMAKE_ARGS += -DCMAKE_OSX_SYSROOT="$(SYSROOT)"
+  endif
+endif # macosx
+
 ifneq (,$(CCACHE))
   # openjdk makefiles add a bunch of environemnt variables to the ccache command.
   # CMake will not parse this properly, so we wrap the whole thing in the env command.


### PR DESCRIPTION
This is a backport of ibmruntimes/openj9-openjdk-jdk#1201

(cherry picked from commit a223f99577cf402f1eae0fbdb8dcf0d65724433c)




---------
- [X] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
