### PR TITLE
Update expectedValueTest by dynamically fetching locale display name

### DIFF
--- a/test/jdk/java/text/Format/CompactNumberFormat/ToStringTest.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/ToStringTest.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8321545
  * @summary Ensure value returned by overridden toString method is as expected
@@ -43,7 +49,8 @@ public class ToStringTest {
     // methods and constructor (which takes DFS) throw NPE if the locale param is null.
     @Test
     public void expectedValueTest() {
-        String expectedStr = "CompactNumberFormat [locale: \"English (Canada)\", decimal pattern: \"#,##0.###\", compact patterns: \"[, , , {one:0' 'thousand other:0' 'thousand}, {one:00' 'thousand other:00' 'thousand}, {one:000' 'thousand other:000' 'thousand}, {one:0' 'million other:0' 'million}, {one:00' 'million other:00' 'million}, {one:000' 'million other:000' 'million}, {one:0' 'billion other:0' 'billion}, {one:00' 'billion other:00' 'billion}, {one:000' 'billion other:000' 'billion}, {one:0' 'trillion other:0' 'trillion}, {one:00' 'trillion other:00' 'trillion}, {one:000' 'trillion other:000' 'trillion}]\"]\n";
+        String localeDisplayName = Locale.CANADA.getDisplayName();
+        String expectedStr = "CompactNumberFormat [locale: \"" + localeDisplayName + "\", decimal pattern: \"#,##0.###\", compact patterns: \"[, , , {one:0' 'thousand other:0' 'thousand}, {one:00' 'thousand other:00' 'thousand}, {one:000' 'thousand other:000' 'thousand}, {one:0' 'million other:0' 'million}, {one:00' 'million other:00' 'million}, {one:000' 'million other:000' 'million}, {one:0' 'billion other:0' 'billion}, {one:00' 'billion other:00' 'billion}, {one:000' 'billion other:000' 'billion}, {one:0' 'trillion other:0' 'trillion}, {one:00' 'trillion other:00' 'trillion}, {one:000' 'trillion other:000' 'trillion}]\"]\n";
         var c = NumberFormat.getCompactNumberInstance(Locale.CANADA, NumberFormat.Style.LONG);
         assertEquals(expectedStr, c.toString());
     }
@@ -51,7 +58,8 @@ public class ToStringTest {
     // Check an odd value with empty decimal pattern and compact patterns.
     @Test
     public void oddValueTest() {
-        String expectedStr = "CompactNumberFormat [locale: \"English (Canada)\", decimal pattern: \"\", compact patterns: \"[]\"]\n";
+        String localeDisplayName = Locale.CANADA.getDisplayName();
+        String expectedStr = "CompactNumberFormat [locale: \"" + localeDisplayName + "\", decimal pattern: \"\", compact patterns: \"[]\"]\n";
         var c = new CompactNumberFormat("", new DecimalFormatSymbols(Locale.CANADA), new String[]{});
         assertEquals(expectedStr, c.toString());
     }


### PR DESCRIPTION
Updated the test scripts to fetch the locale display name dynamically instead of expecting locale name in English.
The existing test script is expecting locale display name in English in all of the mbcs machines but in Chinese & Japanese machines the toString() method uses Locale.getDisplayName() which returns names in the JVM's default locale, it may not be English always.
The fix we will fetch the default locale display name of each machines across all machine and pass to assertTrue for comparison.

Cherry-pick : https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1223
Changes : https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/56c27a6b6f75bf2e99898fc2b715da1e384552d1
Related : https://github.ibm.com/runtimes/automation/issues/881


---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
