### PR TITLE
Support SecureRandom strong algorithms in FIPS mode

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -589,6 +589,7 @@ public final class RestrictedSecurity {
         propsMapping.put("jdk.tls.legacyAlgorithms", restricts.jdkTlsLegacyAlgorithms);
         propsMapping.put("jdk.certpath.disabledAlgorithms", restricts.jdkCertpathDisabledAlgorithms);
         propsMapping.put("jdk.security.legacyAlgorithms", restricts.jdkSecurityLegacyAlgorithms);
+        propsMapping.put("securerandom.strongAlgorithms", restricts.jdkSecureRandomStrongAlgorithms);
 
         if (restricts.descIsFIPS) {
             if (restricts.jdkFipsMode == null) {
@@ -784,6 +785,7 @@ public final class RestrictedSecurity {
         // For SecureRandom.
         final String jdkSecureRandomProvider;
         final String jdkSecureRandomAlgorithm;
+        final String jdkSecureRandomStrongAlgorithms;
 
         final String jdkFipsMode;
 
@@ -818,6 +820,7 @@ public final class RestrictedSecurity {
             // For SecureRandom.
             this.jdkSecureRandomProvider = parser.getProperty("jdkSecureRandomProvider");
             this.jdkSecureRandomAlgorithm = parser.getProperty("jdkSecureRandomAlgorithm");
+            this.jdkSecureRandomStrongAlgorithms = parser.getProperty("jdkSecureRandomStrongAlgorithms");
 
             this.jdkFipsMode = parser.getProperty("jdkFipsMode");
 
@@ -1112,6 +1115,7 @@ public final class RestrictedSecurity {
             printProperty(profileID + ".javax.net.ssl.keyStore: ", keyStore);
             printProperty(profileID + ".securerandom.provider: ", jdkSecureRandomProvider);
             printProperty(profileID + ".securerandom.algorithm: ", jdkSecureRandomAlgorithm);
+            printProperty(profileID + ".securerandom.strongAlgorithms: ", jdkSecureRandomStrongAlgorithms);
             System.out.println();
         }
 
@@ -1515,6 +1519,9 @@ public final class RestrictedSecurity {
                 case "jdkTlsLegacyAlgorithms":
                     propertyKey = "jdk.tls.legacyAlgorithms";
                     break;
+                case "jdkSecureRandomStrongAlgorithms":
+                    propertyKey = "securerandom.strongAlgorithms";
+                    break;
                 default:
                     return null;
                 }
@@ -1568,6 +1575,8 @@ public final class RestrictedSecurity {
                     profileID + ".securerandom.provider", allInfo);
             setProperty("jdkSecureRandomAlgorithm",
                     profileID + ".securerandom.algorithm", allInfo);
+            setProperty("jdkSecureRandomStrongAlgorithms",
+                    profileID + ".securerandom.strongAlgorithms", allInfo);
             setProperty("jdkFipsMode",
                     profileID + ".fips.mode", allInfo);
 
@@ -1913,6 +1922,7 @@ public final class RestrictedSecurity {
             case "jdkTlsDisabledAlgorithms":
             case "jdkTlsDisabledNamedCurves":
             case "jdkTlsLegacyAlgorithms":
+            case "jdkSecureRandomStrongAlgorithms":
                 return true;
             default:
                 return false;

--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2024, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2024, 2026 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -202,6 +202,71 @@ public class TestProperties {
         return tests.build();
     }
 
+    private static Stream<Arguments> patternMatches_strongAlgorithms() {
+        Stream.Builder<Arguments> tests = Stream.builder();
+
+        if (isProviderPresent("OpenJCEPlusFIPS")) {
+            // 1 - Test property - base profile with securerandom.strongAlgorithms loads successfully.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "(?s)(?=.*OpenJCEPlusFIPS)(?=.*SUN)(?=.*SunJSSE)",
+                    0));
+            // 2 - Test property - securerandom.strongAlgorithms property with multiple algorithms.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MultipleEntries",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
+                    0));
+            // 3 - Test property - securerandom.strongAlgorithms append algorithm in extended profile.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_1",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "securerandom\\.strongAlgorithms: SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS",
+                    0));
+            // 4 - Test property - securerandom.strongAlgorithms remove algorithm in extended profile.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Extension_2",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "securerandom\\.strongAlgorithms: (?=.*NativePRNGBlocking:SUN)(?=.*DRBG:SUN)",
+                    0));
+            // 5 - Test property - securerandom.strongAlgorithms invalid algorithm.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidFormat",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 6 - Test property - securerandom.strongAlgorithms missing algorithm.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingAlgo",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 7 - Test property - securerandom.strongAlgorithms missing provider.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MissingProvider",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: missing provider",
+                    0));
+            // 8 - Test property - set invalid provider.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidProvider",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 9 - Test property - securerandom.strongAlgorithms when only algorithm is present.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-Specify-Algo-Only",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "securerandom\\.strongAlgorithms: SHA(256|512)DRBG$",
+                    0));
+            // 10 - Test property - invalid algorithm.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-InvalidAlgorithm",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "FAILED: No strong SecureRandom impls available: .*",
+                    0));
+            // 11 - Test property - securerandom.strongAlgorithms misspelled property name.
+            tests.add(Arguments.of("Test-Profile-strongAlgorithms-MisspelledPropertyName",
+                    System.getProperty("test.src") + "/property-java.security",
+                    "The property names: RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.strongAlgorithmsWrong "
+                            + "in profile RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName \\(or a base profile\\) are not recognized",
+                    1));
+        }
+
+        return tests.build();
+    }
+
     @ParameterizedTest
     @MethodSource("patternMatches_expectedExitValue0")
     public void shouldContain_expectedExitValue0(String customprofile, String securityPropertyFile, String expected) throws Exception {
@@ -241,6 +306,19 @@ public class TestProperties {
         outputAnalyzer.shouldHaveExitValue(exitValue).shouldMatch(expected);
     }
 
+    @ParameterizedTest
+    @MethodSource("patternMatches_strongAlgorithms")
+    public void shouldContain_strongAlgorithms(String customprofile, String securityPropertyFile, String expected, int exitValue) throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.fips=true",
+                "-Dsemeru.customprofile=" + customprofile,
+                "-Djava.security.properties=" + securityPropertyFile,
+                "TestProperties"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(exitValue).shouldMatch(expected);
+    }
+
     private static boolean isProviderPresent(String providerName) {
         for (Provider provider : Security.getProviders()) {
             if (provider.getName().equalsIgnoreCase(providerName)) {
@@ -250,6 +328,20 @@ public class TestProperties {
         return false;
     }
 
+    private static void testStrongAlgorithms() {
+        if (isProviderPresent("OpenJCEPlusFIPS")) {
+            String strongAlgorithms = Security.getProperty("securerandom.strongAlgorithms");
+            if ((strongAlgorithms != null) && !strongAlgorithms.isEmpty()) {
+                try {
+                    java.security.SecureRandom.getInstanceStrong();
+                    System.out.println("securerandom.strongAlgorithms: " + strongAlgorithms);
+                } catch (java.security.NoSuchAlgorithmException | IllegalArgumentException e) {
+                    System.out.println("FAILED: " + e.getMessage());
+                }
+            }
+        }
+    }
+
     public static void main(String[] args) {
         // Something to trigger "properties" debug output.
         try {
@@ -257,6 +349,7 @@ public class TestProperties {
                 System.out.println("Provider Name: " + provider.getName());
                 System.out.println("Provider Version: " + provider.getVersionStr());
             }
+            testStrongAlgorithms();
         } catch (Exception e) {
             System.out.println(e);
         }

--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -502,3 +502,149 @@ RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.jce.provider.3 = sun
 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.Test-Profile-SameStartWithoutVersionPart.securerandom.algorithm = SHA512DRBG
+
+#
+# Test-Profile-strongAlgorithms.base
+# Test constraint - securerandom.strongAlgorithms property
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.desc.name = Test-Profile-strongAlgorithms.base
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.desc.hash = SHA256:15d0d3035a4b8add8a1b08c1f8b41158c8cc38f61948fe1b78c6b7d74252cbd3
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.jce.provider.2 = sun.security.provider.Sun
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.jce.provider.3 = sun.security.ssl.SunJSSE
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms.base.securerandom.strongAlgorithms = SHA512DRBG:OpenJCEPlusFIPS
+
+#
+# Test-Profile-strongAlgorithms-MultipleEntries
+# Test constraint - securerandom.strongAlgorithms with multiple comma-separated entries
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.desc.name = Test-Profile-strongAlgorithms-MultipleEntries
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.desc.hash = SHA256:35a311a475dbed6b798965144b62d02eeec0356253d13f7a6fb58d57fc22cced
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-MultipleEntries.securerandom.strongAlgorithms = SHA512DRBG:OpenJCEPlusFIPS, SHA256DRBG:OpenJCEPlusFIPS
+
+#
+# Test-Profile-strongAlgorithms-Extension_1
+# Test constraint - extension profile attempting to append to strongAlgorithms (should be appendable)
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_1.desc.name = Test-Profile-strongAlgorithms-Extension_1
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_1.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_1.extends = RestrictedSecurity.Test-Profile-strongAlgorithms.base
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_1.securerandom.strongAlgorithms = + SHA256DRBG:OpenJCEPlusFIPS
+
+#
+# Test-Profile-strongAlgorithms-Extension_2
+# Test constraint - extension profile attempting to remove algorithm from strongAlgorithms (should be removable)
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_2.desc.name = Test-Profile-strongAlgorithms-Extension_2
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_2.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_2.extends = RestrictedSecurity.Test-Profile-strongAlgorithms.base
+RestrictedSecurity.Test-Profile-strongAlgorithms-Extension_2.securerandom.strongAlgorithms = - SHA512DRBG:OpenJCEPlusFIPS
+
+#
+# Test-Profile-strongAlgorithms-InvalidFormat
+# Test constraint - securerandom.strongAlgorithms with invalid format (multiple colons)
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.desc.name = Test-Profile-strongAlgorithms-InvalidFormat
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.desc.hash = SHA256:978854ed93fb41febb23e9ccf1fbec95f0a5b6823c3a2dc9d2f09555ec95c71f
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidFormat.securerandom.strongAlgorithms = SHA512DRBG:OpenJCEPlusFIPS:InvalidFormat
+
+#
+# Test-Profile-strongAlgorithms-MissingAlgo
+# Test constraint - securerandom.strongAlgorithms with missing/empty algorithm
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.desc.name = Test-Profile-strongAlgorithms-MissingAlgo
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.desc.hash = SHA256:b107da504173da48a39bab3e178432b91459043b6f25d5c7611bd931c2b35feb
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingAlgo.securerandom.strongAlgorithms = :OpenJCEPlusFIPS
+
+#
+# Test-Profile-strongAlgorithms-MissingProvider
+# Test constraint - securerandom.strongAlgorithms with missing/empty provider
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.desc.name = Test-Profile-strongAlgorithms-MissingProvider
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.desc.hash = SHA256:547e9fdd282588118c8b0898dd81a6ef76d4a084b6ded610c75c7720ae658e45
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-MissingProvider.securerandom.strongAlgorithms = SHA512DRBG:
+
+#
+# Test-Profile-strongAlgorithms-InvalidProvider
+# Test constraint - securerandom.strongAlgorithms with invalid provider
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.desc.name = Test-Profile-strongAlgorithms-InvalidProvider
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.desc.hash = SHA256:d433db92909da445919d24f97a844d57b2c092ff26db6afd96e021daee065e19
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidProvider.securerandom.strongAlgorithms = SHA512DRBG:InvalidProvider
+
+#
+# Test-Profile-strongAlgorithms-Specify-Algo-Only
+# Test constraint - securerandom.strongAlgorithms specify algorithm only
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.desc.name = Test-Profile-strongAlgorithms-Specify-Algo-Only
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.desc.hash = SHA256:c4a9b128ad3e027c846fe7a7556820a494f6c27aa278478e257684fb6da4fac1
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-Specify-Algo-Only.securerandom.strongAlgorithms = SHA512DRBG
+
+#
+# Test-Profile-strongAlgorithms-InvalidAlgorithm
+# Test constraint - securerandom.strongAlgorithms with invalid algorithm
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.desc.name = Test-Profile-strongAlgorithms-InvalidAlgorithm
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.desc.hash = SHA256:1f42538f7a48ee287fa890420d3e47ecc6dcc5d7b4900acc1d4071c62ea566fb
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-InvalidAlgorithm.securerandom.strongAlgorithms = InvalidAlgorithm:OpenJCEPlusFIPS
+
+#
+# Test-Profile-strongAlgorithms-MisspelledPropertyName
+# Test constraint - securerandom.strongAlgorithms property name misspelled
+#
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.desc.name = Test-Profile-strongAlgorithms-MisspelledPropertyName
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.desc.default = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.desc.fips = true
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.desc.hash = SHA256:831e7e7aa5b81ab9e8f522d81ff95bff6833c9421d65bff7f8944e538b13e973
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.fips.mode = 140-3
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.jce.provider.1 = com.ibm.crypto.plus.provider.OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.provider = OpenJCEPlusFIPS
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.Test-Profile-strongAlgorithms-MisspelledPropertyName.securerandom.strongAlgorithmsWrong = SHA512DRBG:OpenJCEPlusFIPS

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -210,7 +210,7 @@ RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.name = OpenJCEPlusFIPS Cryptographic Module FIPS 140-3
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.default = false
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
-RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:db77222175971874d5681342bb2ee2f95258e6bc7e9957a7c027a7a41b03af90
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.hash = SHA256:488826302be498c47d45f798b8705297241434e522b983be5bd8abc759d8aab5
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #4755
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4755
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2029-08-08
@@ -350,6 +350,7 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.jce.provider.3 = sun.security.ssl.S
 
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.securerandom.provider = OpenJCEPlusFIPS
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.securerandom.algorithm = SHA512DRBG
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.securerandom.strongAlgorithms = SHA512DRBG:OpenJCEPlusFIPS
 
 # Strongly enforced restricted security mode profile for FIPS 140-3.
 #


### PR DESCRIPTION
This change overrides the default securerandom.strongAlgorithms configuration used by SecureRandom.getInstanceStrong() when it runs in FIPS mode.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1187

Signed-off-by: Mohit Rajbhar <mohit.rajbhar@ibm.com>