### PR TITLE
Avoid warning from macOS linker on x86_64

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2025 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2026 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -122,8 +122,8 @@ ifeq ($(OPENJDK_TARGET_OS), macosx)
   export MACOSX_DEPLOYMENT_TARGET := @MACOSX_VERSION_MIN@
 
   ifneq ($(OPENJDK_TARGET_CPU), aarch64)
-    # Set page zero size to 4KB for mapping memory below 4GB.
-    LDFLAGS_JDKEXE += -pagezero_size 0x1000
+    # Set page zero size to 16KB for mapping memory below 4GB.
+    LDFLAGS_JDKEXE += -pagezero_size 0x4000
   endif
 endif
 


### PR DESCRIPTION
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1226.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).