### PR TITLE
Tweak make macro name

### DIFF
--- a/closed/DDR.gmk
+++ b/closed/DDR.gmk
@@ -183,7 +183,7 @@ ifneq (,$(wildcard $(DDR_GENSRC_DIR)))
 
 # Compile DDR code again, to ensure compatibility with class files
 # as they would be dynamically generated from the blob.
-$(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
+$(eval $(call SetupJavaCompilation,BUILD_DDR_TEST_CLASSES, \
 	DEPENDS := $(DDR_CLASSES_MARKER), \
 	JAVAC_FLAGS := \
 		--patch-module openj9.dtfj=$(DDR_CLASSES_BIN) \
@@ -196,6 +196,6 @@ $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
 
 .PHONY : compile_check
 
-compile_check : $(BUILD_J9DDR_TEST_CLASSES)
+compile_check : $(BUILD_DDR_TEST_CLASSES)
 
 endif # DDR_GENSRC_DIR


### PR DESCRIPTION
Use `BUILD_DDR` prefix consistently instead of `BUILD_J9DDR`.

This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1234.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).