### PR TITLE
Enable SSLLogger message for Hybrid Key Exchange

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/Hybrid.java
+++ b/src/java.base/share/classes/sun/security/ssl/Hybrid.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.ssl;
 
 import sun.security.util.ArrayUtil;
@@ -125,6 +131,11 @@ public class Hybrid {
             right = getKeyPairGenerator(rightAlg);
             leftSpec = getSpec(leftAlg);
             rightSpec = getSpec(rightAlg);
+            if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                SSLLogger.finer("Hybrid KeyPairGenerator:\n"
+                        + "  " + leftAlg + " is from " + left.getProvider().getName() + "\n"
+                        + "  " + rightAlg + " is from " + right.getProvider().getName() + "\n");
+            }
         }
 
         @Override
@@ -144,6 +155,13 @@ public class Hybrid {
         public KeyPair generateKeyPair() {
             var kp1 = left.generateKeyPair();
             var kp2 = right.generateKeyPair();
+            if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                SSLLogger.finer("Hybrid KeyPairGenerator:\n"
+                        + "  left publicKey is from " + kp1.getPublic().getClass().getName() + ", "
+                        + "privateKey is from " + kp1.getPrivate().getClass().getName() + "\n"
+                        + "  right publicKey is from " + kp2.getPublic().getClass().getName() + ", "
+                        + "privateKey is from " + kp2.getPrivate().getClass().getName() + "\n");
+            }
             return new KeyPair(
                     new PublicKeyImpl("Hybrid", kp1.getPublic(),
                             kp2.getPublic()),
@@ -222,6 +240,14 @@ public class Hybrid {
                                 " algorithm: " + rightname);
                     }
 
+                    if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                        SSLLogger.finer("Hybrid KeyFactory:\n"
+                                + "  " + this.leftname + " is from " + this.left.getProvider().getName() + ", "
+                                + "left publicKey from " + leftKey.getClass().getName() + "\n"
+                                + "  " + this.rightname + " is from " + this.right.getProvider().getName() + ", "
+                                + "right publicKey from " + rightKey.getClass().getName());
+                    }
+
                     return new PublicKeyImpl("Hybrid", leftKey, rightKey);
                 } catch (Exception e) {
                     throw new InvalidKeySpecException("Failed to decode " +
@@ -265,11 +291,15 @@ public class Hybrid {
     public static class KEMImpl implements KEMSpi {
         private final KEM left;
         private final KEM right;
+        private final String leftname;
+        private final String rightname;
 
         public KEMImpl(String left, String right)
                 throws NoSuchAlgorithmException {
             this.left = getKEM(left);
             this.right = getKEM(right);
+            this.leftname = left;
+            this.rightname = right;
         }
 
         @Override
@@ -277,9 +307,20 @@ public class Hybrid {
                 AlgorithmParameterSpec spec, SecureRandom secureRandom) throws
                 InvalidAlgorithmParameterException, InvalidKeyException {
             if (publicKey instanceof PublicKeyImpl pk) {
-                return new Handler(left.newEncapsulator(pk.left, secureRandom),
-                        right.newEncapsulator(pk.right, secureRandom),
-                        null, null);
+                KEM.Encapsulator leftEnc = left.newEncapsulator(pk.left, secureRandom);
+                KEM.Encapsulator rightEnc = right.newEncapsulator(pk.right, secureRandom);
+
+                if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                    SSLLogger.finer("Hybrid KEM NewEncapsulator:\n"
+                            + "  LeftEnc [" + leftname + "]: Provider=" + leftEnc.providerName()
+                            + ", KEMClass=" + left.getClass().getName()
+                            + ", KeyClass=" + pk.left.getClass().getName() + "\n"
+                            + "  RightEnc [" + rightname + "]: Provider=" + rightEnc.providerName()
+                            + ", KEMClass=" + right.getClass().getName()
+                            + ", KeyClass=" + pk.right.getClass().getName());
+                }
+
+                return new Handler(leftEnc, rightEnc, null, null);
             }
             throw new InvalidKeyException();
         }
@@ -289,8 +330,20 @@ public class Hybrid {
                 AlgorithmParameterSpec spec)
                 throws InvalidAlgorithmParameterException, InvalidKeyException {
             if (privateKey instanceof PrivateKeyImpl pk) {
-                return new Handler(null, null, left.newDecapsulator(pk.left),
-                        right.newDecapsulator(pk.right));
+                KEM.Decapsulator leftDec = left.newDecapsulator(pk.left);
+                KEM.Decapsulator rightDec = right.newDecapsulator(pk.right);
+
+                if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                    SSLLogger.finer("Hybrid KEM NewDecapsulator:\n"
+                            + "  LeftDec [" + leftname + "]: Provider=" + leftDec.providerName()
+                            + ", KEMClass=" + left.getClass().getName()
+                            + ", KeyImpl=" + pk.left.getClass().getName() + "\n"
+                            + "  RightDec [" + rightname + "]: Provider=" + rightDec.providerName()
+                            + ", KEMClass=" + right.getClass().getName()
+                            + ", KeyImpl=" + pk.right.getClass().getName());
+                }
+
+                return new Handler(null, null, leftDec, rightDec);
             }
             throw new InvalidKeyException();
         }

--- a/src/java.base/share/classes/sun/security/ssl/KAKeyDerivation.java
+++ b/src/java.base/share/classes/sun/security/ssl/KAKeyDerivation.java
@@ -22,6 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.ssl;
 
 import sun.security.util.RawKeySpec;
@@ -135,6 +142,10 @@ public class KAKeyDerivation implements SSLKeyDerivation {
                 earlySecret = hkdf.deriveKey("TlsEarlySecret",
                         HKDFParameterSpec.ofExtract().addSalt(zeros)
                         .addIKM(zeros).extractOnly());
+                if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                    SSLLogger.finer("No PSK is in use, the KDF is from: " + hkdf.getProviderName()
+                            + ", the classname for earlySecret key is " + earlySecret.getClass().getName());
+                }
                 kd = new SSLSecretDerivation(context, earlySecret);
             }
 
@@ -152,8 +163,12 @@ public class KAKeyDerivation implements SSLKeyDerivation {
             } else {
                 spec = spec.addIKM(sharedSecret);
             }
-
-            return hkdf.deriveKey(label, spec.extractOnly());
+            SecretKey result = hkdf.deriveKey(label, spec.extractOnly());
+            if (SSLLogger.isOn && SSLLogger.isOn("ssl,handshake")) {
+                SSLLogger.finer("derive handshake secret, the KDF is from: "
+                        + hkdf.getProviderName() + ", the classname for sharedSecret key is " + result.getClass().getName());
+            }
+            return result;
         } finally {
             KeyUtil.destroySecretKeys(earlySecret, saltSecret);
         }


### PR DESCRIPTION
Adding debug print for hybrid key exchange, this would be easier for us to identify the issue.

Backport from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1215



---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
