### PR TITLE
Allow aliases in RestrictedSecurity constraints

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -270,7 +270,7 @@ public final class RestrictedSecurity {
     public static boolean isServiceAllowed(Service service) {
         if (securityEnabled) {
             checkHashValues(false);
-            return restricts.isRestrictedServiceAllowed(service, true);
+            return restricts.isRestrictedServiceAllowed(service, true, null);
         }
         return true;
     }
@@ -279,12 +279,13 @@ public final class RestrictedSecurity {
      * Check if the service is allowed to be registered in restricted security mode.
      *
      * @param service the service to check
+     * @param aliases a list of aliases for the algorithm name of the service
      * @return true if the service is allowed to be registered
      */
-    public static boolean canServiceBeRegistered(Service service) {
+    public static boolean canServiceBeRegistered(Service service, List<String> aliases) {
         if (securityEnabled) {
             checkHashValues(false);
-            return restricts.isRestrictedServiceAllowed(service, false);
+            return restricts.isRestrictedServiceAllowed(service, false, aliases);
         }
         return true;
     }
@@ -858,9 +859,11 @@ public final class RestrictedSecurity {
          *
          * @param service   the Service to check
          * @param checkUse  should its attempted use be checked against the accepted
+         * @param aliases   a list of aliases for the algorithm name of the service
+         *                  (could be null if no aliases are available)
          * @return true if the Service is allowed
          */
-        boolean isRestrictedServiceAllowed(Service service, boolean checkUse) {
+        boolean isRestrictedServiceAllowed(Service service, boolean checkUse, List<String> aliases) {
             Provider provider = service.getProvider();
             String providerClassName = provider.getClass().getName();
 
@@ -914,11 +917,22 @@ public final class RestrictedSecurity {
                     continue constraints;
                 }
                 if (!isAsterisk(cAlgorithm) && !algorithm.equalsIgnoreCase(cAlgorithm)) {
-                    // The constraint doesn't apply to the service algorithm.
-                    if (debug != null) {
-                        debug.println("The constraint doesn't apply to the service algorithm.");
+                    // Check if the algorithm name in the constraint is an alias (case-insensitive).
+                    if ((aliases != null)
+                            && aliases.stream().anyMatch(cAlgorithm::equalsIgnoreCase)
+                    ) {
+                        // Fix the constraint to have the registered name.
+                        constraint.setAlgorithm(algorithm);
+                        if (debug != null) {
+                            debug.println("Constraint had an alias ('" + cAlgorithm + "'). Switching to registered ('" + algorithm + "').");
+                        }
+                    } else {
+                        // The constraint doesn't apply to the service algorithm.
+                        if (debug != null) {
+                            debug.println("The constraint doesn't apply to the service algorithm.");
+                        }
+                        continue constraints;
                     }
-                    continue constraints;
                 }
 
                 // For type and algorithm match, and attribute is not *.
@@ -2031,7 +2045,7 @@ public final class RestrictedSecurity {
      */
     private static final class Constraint {
         final String type;
-        final String algorithm;
+        String algorithm;
         final String attributes;
         final String acceptedUses;
 
@@ -2041,6 +2055,10 @@ public final class RestrictedSecurity {
             this.algorithm = algorithm;
             this.attributes = attributes;
             this.acceptedUses = acceptedUses;
+        }
+
+        void setAlgorithm(String algorithm) {
+            this.algorithm = algorithm;
         }
 
         @Override

--- a/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
+++ b/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2025, 2026 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,12 @@ public class TestConstraintsSuccess {
         // middle one having the correct attributes, successfully getting the
         // algorithm verifies that all constraints are checked.
         Signature.getInstance("SHA512withECDSA");
+
+        // Request algorithm whose alias has been specified in the constraint.
+        // Ask for it using both its registered name and an alias (with some
+        // changes in capitalization to check case-insensitivity).
+        MessageDigest.getInstance("SHA-384");
+        MessageDigest.getInstance("Sha384");
     }
 
     @Test

--- a/closed/test/jdk/openj9/internal/security/constraints-java.security
+++ b/closed/test/jdk/openj9/internal/security/constraints-java.security
@@ -21,7 +21,7 @@
 RestrictedSecurity.TestConstraints.Version.desc.name = Test Base Profile
 RestrictedSecurity.TestConstraints.Version.desc.default = false
 RestrictedSecurity.TestConstraints.Version.desc.fips = false
-RestrictedSecurity.TestConstraints.Version.desc.hash = SHA256:b41218d53d399ecc15701fcef1afd2c6c16903c8f959041e83ca00107a38e231
+RestrictedSecurity.TestConstraints.Version.desc.hash = SHA256:8229c32c4a80112c6afaba53f7d4747147b49222edacd13750d4ed672b4a7e42
 RestrictedSecurity.TestConstraints.Version.fips.mode = test
 
 RestrictedSecurity.TestConstraints.Version.jce.provider.1 = sun.security.provider.Sun [ \
@@ -35,6 +35,7 @@ RestrictedSecurity.TestConstraints.Version.jce.provider.1 = sun.security.provide
     {MessageDigest, MD5, *, FullClassName:TestConstraintsSuccess}, \
     {MessageDigest, MD5, *, FullClassName:AnotherNonExistingClass}, \
     {MessageDigest, SHA-256, *}, \
+    {MessageDigest, sha384, *, FullClassName:TestConstraintsSuccess}, \
     {MessageDigest, SHA-512, *, FullClassName:TestConstraintsSuccess}, \
     {KeyStore, PKCS12, *, FullClassName:TestConstraintsSuccess}]
 RestrictedSecurity.TestConstraints.Version.jce.provider.2 = sun.security.ec.SunEC [ \

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2026 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1247,7 +1247,7 @@ public abstract class Provider extends Properties {
             throw new IllegalArgumentException
                     ("service.getProvider() must match this Provider object");
         }
-        if (!RestrictedSecurity.canServiceBeRegistered(s)) {
+        if (!RestrictedSecurity.canServiceBeRegistered(s, s.getAliases())) {
             // We're in restricted security mode which does not allow this service,
             // return without registering.
             return;


### PR DESCRIPTION
When defining constraints for specific services allowed by specific providers, one can now use an alias instead of the original algorithm name.

A test case has, also, been added to verify said functionality.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1241

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
